### PR TITLE
Allow PHPUnit to run v5/6/7, depending on the version of PHP installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"setasign/fpdi": "^2.1"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7",
+		"phpunit/phpunit": "^5.0 || ^6.0 || ^7.0",
 		"mockery/mockery": "^1.3.0",
 		"squizlabs/php_codesniffer": "^3.5.0",
 		"tracy/tracy": "^2.4",
@@ -51,7 +51,17 @@
 			"Mpdf\\": "tests/Mpdf"
 		},
 		"files": [
-			"src/functions-dev.php"
+			"src/functions-dev.php",
+			"tests/includes/phpunit7/MockObject/Builder/NamespaceMatch.php",
+			"tests/includes/phpunit7/MockObject/Builder/ParametersMatch.php",
+			"tests/includes/phpunit7/MockObject/InvocationMocker.php",
+			"tests/includes/phpunit7/MockObject/MockMethod.php"
+		],
+		"exclude-from-classmap": [
+			"vendor/phpunit/phpunit/src/Framework/MockObject/Builder/NamespaceMatch.php",
+			"vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php",
+			"vendor/phpunit/phpunit/src/Framework/MockObject/InvocationMocker.php",
+			"vendor/phpunit/phpunit/src/Framework/MockObject/MockMethod.php"
 		]
 	},
 	"scripts": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
 	backupGlobals="false">
 
 	<testsuites>
-		<testsuite>
+		<testsuite name="unit">
 			<directory suffix=".php">./tests</directory>
 		</testsuite>
 	</testsuites>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -40,4 +40,7 @@
             <property name="tabIndent" value="true" />
         </properties>
     </rule>
+
+    <exclude-pattern>/tests/includes/phpunit6/compatibility.php</exclude-pattern>
+    <exclude-pattern>/tests/includes/phpunit7/MockObject/*</exclude-pattern>
 </ruleset>

--- a/tests/Issues/Issue1042Test.php
+++ b/tests/Issues/Issue1042Test.php
@@ -19,7 +19,8 @@ class Issue1042Test extends \Mpdf\BaseMpdfTest
 
 		$this->mpdf->WriteHtml($html, 2);
 
-		$out = $this->mpdf->Output('', 'S');
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue1056Test.php
+++ b/tests/Issues/Issue1056Test.php
@@ -15,7 +15,8 @@ class Issue1056Test extends \Mpdf\BaseMpdfTest
 
 		$this->mpdf->WriteHtml($html, 2);
 
-		$out = $this->mpdf->Output('', 'S');
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 	public function testInvalidCollationGroupRequire()
@@ -26,7 +27,8 @@ class Issue1056Test extends \Mpdf\BaseMpdfTest
 
 		$this->mpdf->WriteHtml($html, 2);
 
-		$out = $this->mpdf->Output('', 'S');
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue1194Test.php
+++ b/tests/Issues/Issue1194Test.php
@@ -10,6 +10,9 @@ class Issue1194Test extends \PHPUnit_Framework_TestCase
 		$mpdf = new \Mpdf\Mpdf();
 
 		$mpdf->WriteHTML('<table><tbody><tr><td style="text-align: inherit">foo</td></tr></tbody></table>');
+
+		$output = $mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue1197Test.php
+++ b/tests/Issues/Issue1197Test.php
@@ -10,5 +10,8 @@ class Issue1197Test extends \PHPUnit_Framework_TestCase
 		$mpdf = new \Mpdf\Mpdf();
 
 		$mpdf->setCSS(['FONT-SIZE' => ''], 'INLINE');
+
+		$output = $mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 }

--- a/tests/Issues/Issue1204Test.php
+++ b/tests/Issues/Issue1204Test.php
@@ -18,6 +18,9 @@ class Issue1204Test extends \PHPUnit_Framework_TestCase
 
 		$mpdf->WriteHTML('<a href="chrome-extension://fooobarextension"></a>');
 		$mpdf->WriteHTML('<img src="chrome-extension://fooobarextension">');
+
+		$output = $mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue400Test.php
+++ b/tests/Issues/Issue400Test.php
@@ -28,6 +28,9 @@ class Issue400Test extends \Mpdf\BaseMpdfTest
 		<div class="myfixed2">2 Praesent pharetra nulla in turpis. Sed ipsum nulla, sodales nec, vulputate in, scelerisque vitae, magna. Sed egestas justo nec ipsum. Nulla facilisi. Praesent sit amet pede quis metus aliquet vulputate. Donec luctus. Cras euismod tellus vel leo.</div>';
 
 		$this->mpdf->WriteHtml($html);
+
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue419Test.php
+++ b/tests/Issues/Issue419Test.php
@@ -18,6 +18,9 @@ class Issue419Test extends \Mpdf\BaseMpdfTest
 		</style>';
 
 		$this->mpdf->WriteHtml($html);
+
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue510Test.php
+++ b/tests/Issues/Issue510Test.php
@@ -26,7 +26,9 @@ class Issue510Test extends \Mpdf\BaseMpdfTest
 		</html>';
 
 		$this->mpdf->WriteHTML($html);
-		$this->mpdf->Output('', 'S');
+
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue539Test.php
+++ b/tests/Issues/Issue539Test.php
@@ -18,7 +18,8 @@ class Issue539Test extends \Mpdf\BaseMpdfTest
 		$this->mpdf->setCompression(false);
 		$this->mpdf->WriteHTML($html);
 
-		$out = $this->mpdf->output('', 'S');
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue557Test.php
+++ b/tests/Issues/Issue557Test.php
@@ -40,7 +40,8 @@ class Issue557Test extends \Mpdf\BaseMpdfTest
 		$this->mpdf->setCompression(false);
 		$this->mpdf->WriteHTML($html);
 
-		$out = $this->mpdf->output('', 'S');
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue562Test.php
+++ b/tests/Issues/Issue562Test.php
@@ -34,7 +34,8 @@ class Issue562Test extends \Mpdf\BaseMpdfTest
 		$this->mpdf->setCompression(false);
 		$this->mpdf->WriteHTML($html);
 
-		$out = $this->mpdf->output('', 'S');
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue617Test.php
+++ b/tests/Issues/Issue617Test.php
@@ -64,7 +64,9 @@ class Issue617Test extends \Mpdf\BaseMpdfTest
 
 		$mpdf1 = new \Mpdf\Mpdf();
 		$mpdf1->WriteHTML($html);
-		$mpdf1->Output('', 'S');
+
+		$output = $mpdf1->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 
 }

--- a/tests/Issues/Issue993Test.php
+++ b/tests/Issues/Issue993Test.php
@@ -16,6 +16,7 @@ class Issue993Test extends \Mpdf\BaseMpdfTest
 		$this->mpdf->showImageErrors = true;
 		$this->mpdf->WriteHtml($html);
 
-		$out = $this->mpdf->Output('', 'S');
+		$output = $this->mpdf->output('', 'S');
+		$this->assertStringStartsWith('%PDF-', $output);
 	}
 }

--- a/tests/Mpdf/AddFontTest.php
+++ b/tests/Mpdf/AddFontTest.php
@@ -20,6 +20,7 @@ class AddFontTest extends \PHPUnit_Framework_TestCase
 	public function testAddFont()
 	{
 		$this->mpdf->AddFont('sun-exta');
+		$this->assertArrayHasKey('sun-exta', $this->mpdf->FontFiles);
 	}
 
 	/**

--- a/tests/Mpdf/Fonts/MetricsGeneratorTest.php
+++ b/tests/Mpdf/Fonts/MetricsGeneratorTest.php
@@ -32,6 +32,9 @@ class MetricsGeneratorTest extends \PHPUnit_Framework_TestCase
 		Mockery::close();
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function testGenerateMetrics()
 	{
 		$this->fontCache->shouldReceive('jsonWrite')->with('angerthas.mtx.json', Mockery::any())->once();

--- a/tests/Mpdf/Image/SvgTest.php
+++ b/tests/Mpdf/Image/SvgTest.php
@@ -68,7 +68,7 @@ class SvgTest extends \PHPUnit_Framework_TestCase
 		$this->sizeConverter->shouldReceive('convert')->twice()->andReturn(0);
 		$this->colorConverter->shouldReceive('convert')->times(140)->andReturn(0);
 
-		$this->svg->ImageSVG($data);
+		$this->assertCount(5, $this->svg->ImageSVG($data));
 	}
 
 	public function testLogoManageroneSvgImage()
@@ -78,7 +78,7 @@ class SvgTest extends \PHPUnit_Framework_TestCase
 		$this->sizeConverter->shouldReceive('convert')->times(2)->andReturn(0);
 		$this->colorConverter->shouldReceive('convert')->times(1)->andReturn(0);
 
-		$this->svg->ImageSVG($data);
+		$this->assertCount(5, $this->svg->ImageSVG($data));
 	}
 
 	public function testLogoLivingparisianSvgImage()
@@ -87,7 +87,7 @@ class SvgTest extends \PHPUnit_Framework_TestCase
 
 		$this->colorConverter->shouldReceive('convert')->times(28)->andReturn(0);
 
-		$this->svg->ImageSVG($data);
+		$this->assertCount(5, $this->svg->ImageSVG($data));
 	}
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,13 @@ namespace Mpdf;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+/*
+ * Compatibility with PHPUnit 6+
+ */
+if (class_exists('PHPUnit\Runner\Version')) {
+	require_once __DIR__ . '/includes/phpunit6/compatibility.php';
+}
+
 // Create a new instance of the mPDF class
 // We do this here to force the autoloader to include the actual file and its constants
 // It means tests will have access to all of mPDF's constants without first creating a new instance (and everything is loaded)

--- a/tests/includes/phpunit6/compatibility.php
+++ b/tests/includes/phpunit6/compatibility.php
@@ -1,0 +1,43 @@
+<?php
+
+if (class_exists('PHPUnit\Runner\Version') && version_compare(PHPUnit\Runner\Version::id(), '6.0', '>=')) {
+
+	class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+	class_alias('PHPUnit\Framework\Exception', 'PHPUnit_Framework_Exception');
+	class_alias('PHPUnit\Framework\ExpectationFailedException', 'PHPUnit_Framework_ExpectationFailedException');
+	class_alias('PHPUnit\Framework\Error\Deprecated', 'PHPUnit_Framework_Error_Deprecated');
+	class_alias('PHPUnit\Framework\Error\Notice', 'PHPUnit_Framework_Error_Notice');
+	class_alias('PHPUnit\Framework\Error\Warning', 'PHPUnit_Framework_Error_Warning');
+	class_alias('PHPUnit\Framework\Test', 'PHPUnit_Framework_Test');
+	class_alias('PHPUnit\Framework\Warning', 'PHPUnit_Framework_Warning');
+	class_alias('PHPUnit\Framework\AssertionFailedError', 'PHPUnit_Framework_AssertionFailedError');
+	class_alias('PHPUnit\Framework\Constraint\IsEqual', 'PHPUnit_Framework_Constraint_IsEqual');
+	class_alias('PHPUnit\Framework\TestSuite', 'PHPUnit_Framework_TestSuite');
+	class_alias('PHPUnit\Framework\TestListener', 'PHPUnit_Framework_TestListener');
+	class_alias('PHPUnit\Util\GlobalState', 'PHPUnit_Util_GlobalState');
+	class_alias('PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt');
+
+	class PHPUnit_Util_Test
+	{
+
+		// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		public static function getTickets($class_name, $method_name)
+		{
+			$annotations = PHPUnit\Util\Test::parseTestMethodAnnotations($class_name, $method_name);
+
+			$tickets = array();
+
+			if (isset($annotations['class']['ticket'])) {
+				$tickets = $annotations['class']['ticket'];
+			}
+
+			if (isset($annotations['method']['ticket'])) {
+				$tickets = array_merge($tickets, $annotations['method']['ticket']);
+			}
+
+			return array_unique($tickets);
+		}
+
+	}
+
+}

--- a/tests/includes/phpunit7/MockObject/Builder/NamespaceMatch.php
+++ b/tests/includes/phpunit7/MockObject/Builder/NamespaceMatch.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * This file is modified to replace the Match interface with ParametersMatch,
+ * to avoid parse errors due to `match` being a reserved keyword in PHP 8.
+ * 
+ * When the test suite is updated for compatibility with PHPUnit 9.x,
+ * this override can be removed.
+ * 
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Builder;
+
+/**
+ * Interface for builders which can register builders with a given identification.
+ *
+ * This interface relates to Identity.
+ */
+interface NamespaceMatch
+{
+    /**
+     * Looks up the match builder with identification $id and returns it.
+     *
+     * @param string $id The identification of the match builder
+     *
+     * @return Match
+     */
+    public function lookupId($id);
+
+    /**
+     * Registers the match builder $builder with the identification $id. The
+     * builder can later be looked up using lookupId() to figure out if it
+     * has been invoked.
+     *
+     * @param string $id      The identification of the match builder
+     * @param Match  $builder The builder which is being registered
+     */
+    public function registerId($id, ParametersMatch $builder);
+}

--- a/tests/includes/phpunit7/MockObject/Builder/ParametersMatch.php
+++ b/tests/includes/phpunit7/MockObject/Builder/ParametersMatch.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * This file is modified to replace the Match interface with ParametersMatch,
+ * to avoid parse errors due to `match` being a reserved keyword in PHP 8.
+ * 
+ * When the test suite is updated for compatibility with PHPUnit 9.x,
+ * this override can be removed.
+ * 
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Builder;
+
+use PHPUnit\Framework\MockObject\Matcher\AnyParameters;
+
+/**
+ * Builder interface for parameter matchers.
+ */
+interface ParametersMatch extends Stub
+{
+    /**
+     * Defines the expectation which must occur before the current is valid.
+     *
+     * @param string $id the identification of the expectation that should
+     *                   occur before this one
+     *
+     * @return Stub
+     */
+    public function after($id);
+
+    /**
+     * Sets the parameters to match for, each parameter to this function will
+     * be part of match. To perform specific matches or constraints create a
+     * new PHPUnit\Framework\Constraint\Constraint and use it for the parameter.
+     * If the parameter value is not a constraint it will use the
+     * PHPUnit\Framework\Constraint\IsEqual for the value.
+     *
+     * Some examples:
+     * <code>
+     * // match first parameter with value 2
+     * $b->with(2);
+     * // match first parameter with value 'smock' and second identical to 42
+     * $b->with('smock', new PHPUnit\Framework\Constraint\IsEqual(42));
+     * </code>
+     *
+     * @return ParametersMatch
+     */
+    public function with(...$arguments);
+
+    /**
+     * Sets a matcher which allows any kind of parameters.
+     *
+     * Some examples:
+     * <code>
+     * // match any number of parameters
+     * $b->withAnyParameters();
+     * </code>
+     *
+     * @return AnyParameters
+     */
+    public function withAnyParameters();
+}

--- a/tests/includes/phpunit7/MockObject/Generator/deprecation.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/deprecation.tpl.dist
@@ -1,0 +1,2 @@
+
+        @trigger_error({deprecation}, E_USER_DEPRECATED);

--- a/tests/includes/phpunit7/MockObject/Generator/mocked_class.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/mocked_class.tpl.dist
@@ -1,0 +1,46 @@
+{prologue}{class_declaration}
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+    private $__phpunit_configurable = {configurable};
+    private $__phpunit_returnValueGeneration = true;
+
+{clone}{mocked_methods}
+    public function expects(\PHPUnit\Framework\MockObject\Matcher\Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+{method}
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === null) {
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify(bool $unsetInvocationMocker = true)
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+
+        if ($unsetInvocationMocker) {
+            $this->__phpunit_invocationMocker = null;
+        }
+    }
+}{epilogue}

--- a/tests/includes/phpunit7/MockObject/Generator/mocked_class_method.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/mocked_class_method.tpl.dist
@@ -1,0 +1,8 @@
+
+    public function method()
+    {
+        $any     = new \PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
+        $expects = $this->expects($any);
+
+        return call_user_func_array([$expects, 'method'], func_get_args());
+    }

--- a/tests/includes/phpunit7/MockObject/Generator/mocked_clone.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/mocked_clone.tpl.dist
@@ -1,0 +1,4 @@
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }

--- a/tests/includes/phpunit7/MockObject/Generator/mocked_method.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/mocked_method.tpl.dist
@@ -1,0 +1,22 @@
+
+    {modifier} function {reference}{method_name}({arguments_decl}){return_delim}{return_type}
+    {{deprecation}
+        $__phpunit_arguments = [{arguments_call}];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > {arguments_count}) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = {arguments_count}; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $__phpunit_result = $this->__phpunit_getInvocationMocker()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation\ObjectInvocation(
+                '{class_name}', '{method_name}', $__phpunit_arguments, '{return_type}', $this, {clone_arguments}
+            )
+        );
+
+        return $__phpunit_result;
+    }

--- a/tests/includes/phpunit7/MockObject/Generator/mocked_method_void.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/mocked_method_void.tpl.dist
@@ -1,0 +1,20 @@
+
+    {modifier} function {reference}{method_name}({arguments_decl}){return_delim}{return_type}
+    {{deprecation}
+        $__phpunit_arguments = [{arguments_call}];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > {arguments_count}) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = {arguments_count}; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $this->__phpunit_getInvocationMocker()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation\ObjectInvocation(
+                '{class_name}', '{method_name}', $__phpunit_arguments, '{return_type}', $this, {clone_arguments}
+            )
+        );
+    }

--- a/tests/includes/phpunit7/MockObject/Generator/mocked_static_method.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/mocked_static_method.tpl.dist
@@ -1,0 +1,5 @@
+
+    {modifier} function {reference}{method_name}({arguments_decl}){return_delim}{return_type}
+    {
+        throw new \PHPUnit\Framework\MockObject\BadMethodCallException('Static method "{method_name}" cannot be invoked on mock object');
+    }

--- a/tests/includes/phpunit7/MockObject/Generator/proxied_method.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/proxied_method.tpl.dist
@@ -1,0 +1,26 @@
+
+    {modifier} function {reference}{method_name}({arguments_decl}){return_delim}{return_type}
+    {
+        $__phpunit_arguments = [{arguments_call}];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > {arguments_count}) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = {arguments_count}; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $__phpunit_invocation = new \PHPUnit\Framework\MockObject\Invocation\ObjectInvocation(
+            '{class_name}', '{method_name}', $__phpunit_arguments, '{return_type}', $this, {clone_arguments}
+        );
+
+        $__phpunit_invocation->setProxiedCall();
+
+        $this->__phpunit_getInvocationMocker()->invoke($__phpunit_invocation);
+
+        unset($__phpunit_invocation);
+
+        return call_user_func_array(array($this->__phpunit_originalObject, "{method_name}"), $__phpunit_arguments);
+    }

--- a/tests/includes/phpunit7/MockObject/Generator/proxied_method_void.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/proxied_method_void.tpl.dist
@@ -1,0 +1,26 @@
+
+    {modifier} function {reference}{method_name}({arguments_decl}){return_delim}{return_type}
+    {
+        $__phpunit_arguments = [{arguments_call}];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > {arguments_count}) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = {arguments_count}; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $__phpunit_invocation = new \PHPUnit\Framework\MockObject\Invocation\ObjectInvocation(
+            '{class_name}', '{method_name}', $__phpunit_arguments, '{return_type}', $this, {clone_arguments}
+        );
+
+        $__phpunit_invocation->setProxiedCall();
+
+        $this->__phpunit_getInvocationMocker()->invoke($__phpunit_invocation);
+
+        unset($__phpunit_invocation);
+
+        call_user_func_array(array($this->__phpunit_originalObject, "{method_name}"), $__phpunit_arguments);
+    }

--- a/tests/includes/phpunit7/MockObject/Generator/trait_class.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/trait_class.tpl.dist
@@ -1,0 +1,4 @@
+{prologue}class {class_name}
+{
+    use {trait_name};
+}

--- a/tests/includes/phpunit7/MockObject/Generator/unmocked_clone.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/unmocked_clone.tpl.dist
@@ -1,0 +1,5 @@
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+        parent::__clone();
+    }

--- a/tests/includes/phpunit7/MockObject/Generator/wsdl_class.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/wsdl_class.tpl.dist
@@ -1,0 +1,7 @@
+{namespace}class {class_name} extends \SoapClient
+{
+    public function __construct($wsdl, array $options)
+    {
+        parent::__construct('{wsdl}', $options);
+    }
+{methods}}

--- a/tests/includes/phpunit7/MockObject/Generator/wsdl_method.tpl.dist
+++ b/tests/includes/phpunit7/MockObject/Generator/wsdl_method.tpl.dist
@@ -1,0 +1,4 @@
+
+    public function {method_name}({arguments})
+    {
+    }

--- a/tests/includes/phpunit7/MockObject/InvocationMocker.php
+++ b/tests/includes/phpunit7/MockObject/InvocationMocker.php
@@ -1,0 +1,192 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * This file is modified to replace the Match interface with ParametersMatch,
+ * to avoid parse errors due to `match` being a reserved keyword in PHP 8.
+ * 
+ * When the test suite is updated for compatibility with PHPUnit 9.x,
+ * this override can be removed.
+ * 
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use Exception;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\Builder\InvocationMocker as BuilderInvocationMocker;
+use PHPUnit\Framework\MockObject\Builder\ParametersMatch;
+use PHPUnit\Framework\MockObject\Builder\NamespaceMatch;
+use PHPUnit\Framework\MockObject\Matcher\DeferredError;
+use PHPUnit\Framework\MockObject\Matcher\Invocation as MatcherInvocation;
+use PHPUnit\Framework\MockObject\Stub\MatcherCollection;
+
+/**
+ * Mocker for invocations which are sent from
+ * MockObject objects.
+ *
+ * Keeps track of all expectations and stubs as well as registering
+ * identifications for builders.
+ */
+class InvocationMocker implements Invokable, MatcherCollection, NamespaceMatch
+{
+    /**
+     * @var MatcherInvocation[]
+     */
+    private $matchers = [];
+
+    /**
+     * @var Match[]
+     */
+    private $builderMap = [];
+
+    /**
+     * @var string[]
+     */
+    private $configurableMethods;
+
+    /**
+     * @var bool
+     */
+    private $returnValueGeneration;
+
+    public function __construct(array $configurableMethods, bool $returnValueGeneration)
+    {
+        $this->configurableMethods   = $configurableMethods;
+        $this->returnValueGeneration = $returnValueGeneration;
+    }
+
+    public function addMatcher(MatcherInvocation $matcher): void
+    {
+        $this->matchers[] = $matcher;
+    }
+
+    public function hasMatchers()
+    {
+        foreach ($this->matchers as $matcher) {
+            if ($matcher->hasMatchers()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return null|bool
+     */
+    public function lookupId($id)
+    {
+        if (isset($this->builderMap[$id])) {
+            return $this->builderMap[$id];
+        }
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function registerId($id, ParametersMatch $builder): void
+    {
+        if (isset($this->builderMap[$id])) {
+            throw new RuntimeException(
+                'Match builder with id <' . $id . '> is already registered.'
+            );
+        }
+
+        $this->builderMap[$id] = $builder;
+    }
+
+    /**
+     * @return BuilderInvocationMocker
+     */
+    public function expects(MatcherInvocation $matcher)
+    {
+        return new BuilderInvocationMocker(
+            $this,
+            $matcher,
+            $this->configurableMethods
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function invoke(Invocation $invocation)
+    {
+        $exception      = null;
+        $hasReturnValue = false;
+        $returnValue    = null;
+
+        foreach ($this->matchers as $match) {
+            try {
+                if ($match->matches($invocation)) {
+                    $value = $match->invoked($invocation);
+
+                    if (!$hasReturnValue) {
+                        $returnValue    = $value;
+                        $hasReturnValue = true;
+                    }
+                }
+            } catch (Exception $e) {
+                $exception = $e;
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
+
+        if ($hasReturnValue) {
+            return $returnValue;
+        }
+
+        if ($this->returnValueGeneration === false) {
+            $exception = new ExpectationFailedException(
+                \sprintf(
+                    'Return value inference disabled and no expectation set up for %s::%s()',
+                    $invocation->getClassName(),
+                    $invocation->getMethodName()
+                )
+            );
+
+            if (\strtolower($invocation->getMethodName()) === '__tostring') {
+                $this->addMatcher(new DeferredError($exception));
+
+                return '';
+            }
+
+            throw $exception;
+        }
+
+        return $invocation->generateReturnValue();
+    }
+
+    /**
+     * @return bool
+     */
+    public function matches(Invocation $invocation)
+    {
+        foreach ($this->matchers as $matcher) {
+            if (!$matcher->matches($invocation)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     *
+     * @return bool
+     */
+    public function verify()
+    {
+        foreach ($this->matchers as $matcher) {
+            $matcher->verify();
+        }
+    }
+}

--- a/tests/includes/phpunit7/MockObject/LICENSE
+++ b/tests/includes/phpunit7/MockObject/LICENSE
@@ -1,0 +1,33 @@
+PHPUnit
+
+Copyright (c) 2001-2019, Sebastian Bergmann <sebastian@phpunit.de>.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+ * Neither the name of Sebastian Bergmann nor the names of his
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/tests/includes/phpunit7/MockObject/MockMethod.php
+++ b/tests/includes/phpunit7/MockObject/MockMethod.php
@@ -1,0 +1,363 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * This file is modified to replace ReflectionParameter::getClass() usage,
+ * which is deprecated in PHP 8.
+ * 
+ * When the test suite is updated for compatibility with PHPUnit 9.x,
+ * this override can be removed.
+ * 
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use Text_Template;
+
+final class MockMethod
+{
+    /**
+     * @var Text_Template[]
+     */
+    private static $templates = [];
+
+    /**
+     * @var string
+     */
+    private $className;
+
+    /**
+     * @var string
+     */
+    private $methodName;
+
+    /**
+     * @var bool
+     */
+    private $cloneArguments;
+
+    /**
+     * @var string string
+     */
+    private $modifier;
+
+    /**
+     * @var string
+     */
+    private $argumentsForDeclaration;
+
+    /**
+     * @var string
+     */
+    private $argumentsForCall;
+
+    /**
+     * @var string
+     */
+    private $returnType;
+
+    /**
+     * @var string
+     */
+    private $reference;
+
+    /**
+     * @var bool
+     */
+    private $callOriginalMethod;
+
+    /**
+     * @var bool
+     */
+    private $static;
+
+    /**
+     * @var ?string
+     */
+    private $deprecation;
+
+    /**
+     * @var bool
+     */
+    private $allowsReturnNull;
+
+    public static function fromReflection(ReflectionMethod $method, bool $callOriginalMethod, bool $cloneArguments): self
+    {
+        if ($method->isPrivate()) {
+            $modifier = 'private';
+        } elseif ($method->isProtected()) {
+            $modifier = 'protected';
+        } else {
+            $modifier = 'public';
+        }
+
+        if ($method->isStatic()) {
+            $modifier .= ' static';
+        }
+
+        if ($method->returnsReference()) {
+            $reference = '&';
+        } else {
+            $reference = '';
+        }
+
+        if ($method->hasReturnType()) {
+            $returnType = $method->getReturnType()->getName();
+        } else {
+            $returnType = '';
+        }
+
+        $docComment = $method->getDocComment();
+
+        if (\is_string($docComment)
+            && \preg_match('#\*[ \t]*+@deprecated[ \t]*+(.*?)\r?+\n[ \t]*+\*(?:[ \t]*+@|/$)#s', $docComment, $deprecation)
+        ) {
+            $deprecation = \trim(\preg_replace('#[ \t]*\r?\n[ \t]*+\*[ \t]*+#', ' ', $deprecation[1]));
+        } else {
+            $deprecation = null;
+        }
+
+        return new self(
+            $method->getDeclaringClass()->getName(),
+            $method->getName(),
+            $cloneArguments,
+            $modifier,
+            self::getMethodParameters($method),
+            self::getMethodParameters($method, true),
+            $returnType,
+            $reference,
+            $callOriginalMethod,
+            $method->isStatic(),
+            $deprecation,
+            $method->hasReturnType() && $method->getReturnType()->allowsNull()
+        );
+    }
+
+    public static function fromName(string $fullClassName, string $methodName, bool $cloneArguments): self
+    {
+        return new self(
+            $fullClassName,
+            $methodName,
+            $cloneArguments,
+            'public',
+            '',
+            '',
+            '',
+            '',
+            false,
+            false,
+            null,
+            false
+        );
+    }
+
+    public function __construct(string $className, string $methodName, bool $cloneArguments, string $modifier, string $argumentsForDeclaration, string $argumentsForCall, string $returnType, string $reference, bool $callOriginalMethod, bool $static, ?string $deprecation, bool $allowsReturnNull)
+    {
+        $this->className               = $className;
+        $this->methodName              = $methodName;
+        $this->cloneArguments          = $cloneArguments;
+        $this->modifier                = $modifier;
+        $this->argumentsForDeclaration = $argumentsForDeclaration;
+        $this->argumentsForCall        = $argumentsForCall;
+        $this->returnType              = $returnType;
+        $this->reference               = $reference;
+        $this->callOriginalMethod      = $callOriginalMethod;
+        $this->static                  = $static;
+        $this->deprecation             = $deprecation;
+        $this->allowsReturnNull        = $allowsReturnNull;
+    }
+
+    public function getName(): string
+    {
+        return $this->methodName;
+    }
+
+    /**
+     * @throws \ReflectionException
+     * @throws \PHPUnit\Framework\MockObject\RuntimeException
+     * @throws \InvalidArgumentException
+     */
+    public function generateCode(): string
+    {
+        if ($this->static) {
+            $templateFile = 'mocked_static_method.tpl';
+        } elseif ($this->returnType === 'void') {
+            $templateFile = \sprintf(
+                '%s_method_void.tpl',
+                $this->callOriginalMethod ? 'proxied' : 'mocked'
+            );
+        } else {
+            $templateFile = \sprintf(
+                '%s_method.tpl',
+                $this->callOriginalMethod ? 'proxied' : 'mocked'
+            );
+        }
+
+        $returnType = $this->returnType;
+        // @see https://bugs.php.net/bug.php?id=70722
+        if ($returnType === 'self') {
+            $returnType = $this->className;
+        }
+
+        // @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/406
+        if ($returnType === 'parent') {
+            $reflector = new ReflectionClass($this->className);
+
+            $parentClass = $reflector->getParentClass();
+
+            if ($parentClass === false) {
+                throw new RuntimeException(
+                    \sprintf(
+                        'Cannot mock %s::%s because "parent" return type declaration is used but %s does not have a parent class',
+                        $this->className,
+                        $this->methodName,
+                        $this->className
+                    )
+                );
+            }
+
+            $returnType = $parentClass->getName();
+        }
+
+        $deprecation = $this->deprecation;
+
+        if (null !== $this->deprecation) {
+            $deprecation         = "The $this->className::$this->methodName method is deprecated ($this->deprecation).";
+            $deprecationTemplate = $this->getTemplate('deprecation.tpl');
+
+            $deprecationTemplate->setVar([
+                'deprecation' => \var_export($deprecation, true),
+            ]);
+
+            $deprecation = $deprecationTemplate->render();
+        }
+
+        $template = $this->getTemplate($templateFile);
+
+        $template->setVar(
+            [
+                'arguments_decl'  => $this->argumentsForDeclaration,
+                'arguments_call'  => $this->argumentsForCall,
+                'return_delim'    => $returnType ? ': ' : '',
+                'return_type'     => $this->allowsReturnNull ? '?' . $returnType : $returnType,
+                'arguments_count' => !empty($this->argumentsForCall) ? \substr_count($this->argumentsForCall, ',') + 1 : 0,
+                'class_name'      => $this->className,
+                'method_name'     => $this->methodName,
+                'modifier'        => $this->modifier,
+                'reference'       => $this->reference,
+                'clone_arguments' => $this->cloneArguments ? 'true' : 'false',
+                'deprecation'     => $deprecation,
+            ]
+        );
+
+        return $template->render();
+    }
+
+    private function getTemplate(string $template): Text_Template
+    {
+        $filename = __DIR__ . \DIRECTORY_SEPARATOR . 'Generator' . \DIRECTORY_SEPARATOR . $template;
+
+        if (!isset(self::$templates[$filename])) {
+            self::$templates[$filename] = new Text_Template($filename);
+        }
+
+        return self::$templates[$filename];
+    }
+
+    /**
+     * Returns the parameters of a function or method.
+     *
+     * @throws RuntimeException
+     */
+    private static function getMethodParameters(ReflectionMethod $method, bool $forCall = false): string
+    {
+        $parameters = [];
+
+        foreach ($method->getParameters() as $i => $parameter) {
+            $name = '$' . $parameter->getName();
+
+            /* Note: PHP extensions may use empty names for reference arguments
+             * or "..." for methods taking a variable number of arguments.
+             */
+            if ($name === '$' || $name === '$...') {
+                $name = '$arg' . $i;
+            }
+
+            if ($parameter->isVariadic()) {
+                if ($forCall) {
+                    continue;
+                }
+
+                $name = '...' . $name;
+            }
+
+            $nullable        = '';
+            $default         = '';
+            $reference       = '';
+            $typeDeclaration = '';
+
+            if (!$forCall) {
+                if ($parameter->hasType() && $parameter->allowsNull()) {
+                    $nullable = '?';
+                }
+
+                if ($parameter->hasType() && $parameter->getType()->getName() !== 'self') {
+                    $typeDeclaration = $parameter->getType()->getName() . ' ';
+                } else {
+                    try {
+                        $class = $parameter->getType() && !$parameter->getType()->isBuiltin() 
+                            ? new ReflectionClass($parameter->getType()->getName())
+                            : null;
+                    } catch (ReflectionException $e) {
+                        throw new RuntimeException(
+                            \sprintf(
+                                'Cannot mock %s::%s() because a class or ' .
+                                'interface used in the signature is not loaded',
+                                $method->getDeclaringClass()->getName(),
+                                $method->getName()
+                            ),
+                            0,
+                            $e
+                        );
+                    }
+
+                    if ($class !== null) {
+                        $typeDeclaration = $class->getName() . ' ';
+                    }
+                }
+
+                if (!$parameter->isVariadic()) {
+                    if ($parameter->isDefaultValueAvailable()) {
+                        try {
+                            $value = \var_export($parameter->getDefaultValue(), true);
+                        } catch (\ReflectionException $e) {
+                            throw new RuntimeException(
+                                $e->getMessage(),
+                                (int) $e->getCode(),
+                                $e
+                            );
+                        }
+
+                        $default = ' = ' . $value;
+                    } elseif ($parameter->isOptional()) {
+                        $default = ' = null';
+                    }
+                }
+            }
+
+            if ($parameter->isPassedByReference()) {
+                $reference = '&';
+            }
+
+            $parameters[] = $nullable . $typeDeclaration . $reference . $name . $default;
+        }
+
+        return \implode(', ', $parameters);
+    }
+}


### PR DESCRIPTION
While you still need to use --ignore-platform-reqs when running PHP>=8, there is much less chance of running into a PHP error due to legacy code in the testing suite.