### PR TITLE
Remove myclabs/deep-copy dependency via in-place TOC look-ahead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
 		"ext-mbstring": "*",
 		"mpdf/psr-http-message-shim": "^1.0 || ^2.0",
 		"mpdf/psr-log-aware-trait": "^2.0 || ^3.0",
-		"myclabs/deep-copy": "^1.7",
 		"paragonie/random_compat": "^1.4|^2.0|^9.99.99",
 		"psr/http-message": "^1.0 || ^2.0",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",

--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -27513,4 +27513,46 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 		return $html;
 	}
 
+	/**
+	 * Capture a snapshot of mPDFs mutable document state
+	 *
+	 * In combination with {@see restoreStateSnapshot()} this allows for document look-aheads that
+	 * can only be computed by writing to the document. For example, {@see TableOfContents::insertTOC}
+	 * uses this functionality to determine the correct page numbers.
+	 *
+	 * Only scalar and array values are captured in the snapshot. All objects and resources are excluded.
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @internal Needs to be public to let internal mPDF classes use it, but is not part of the public API
+	 */
+	public function getStateSnapshot()
+	{
+		$snapshot = [];
+		foreach (get_object_vars($this) as $key => $value) {
+			if (is_object($value) || is_resource($value)) {
+				continue;
+			}
+
+			$snapshot[$key] = $value;
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Restore document state previously captured by {@see getStateSnapshot()}.
+	 *
+	 * @param array<string, mixed> $snapshot
+	 *
+	 * @return void
+	 *
+	 * @internal Needs to be public to let internal mPDF classes use it, but is not part of the public API
+	 */
+	public function restoreStateSnapshot(array $snapshot)
+	{
+		foreach ($snapshot as $key => $value) {
+			$this->{$key} = $value;
+		}
+	}
 }

--- a/src/TableOfContents.php
+++ b/src/TableOfContents.php
@@ -3,7 +3,6 @@
 namespace Mpdf;
 
 use Mpdf\Utils\Arrays;
-use DeepCopy\DeepCopy;
 
 class TableOfContents
 {
@@ -299,22 +298,32 @@ class TableOfContents
 
 	public function insertTOC()
 	{
-		/*
+		/**
 		 * Fix the TOC page numbering problem
 		 *
-		 * To do this, the current class is deep cloned and then the TOC functionality run. The correct page
-		 * numbers are calculated when the TOC pages are moved into position in the cloned object (see Mpdf::MovePages).
-		 * It's then a matter of copying the correct page numbers to the original object and letting the TOC functionality
-		 * run as per normal.
+		 * The correct page numbers are only known once the TOC pages have been painted and moved into
+		 * position (@see Mpdf::MovePages). To break that chicken-and-egg problem the TOC is first painted
+		 * as a trial "look-ahead" pass, run in-place against a snapshot of the document state. The
+		 * corrected page numbers (and page-number substitutions) are read from that pass, the document is
+		 * rolled back to the snapshot, and the TOC is then painted for real with the correct numbers.
 		 *
-		 * See https://github.com/mpdf/mpdf/issues/642
+		 * @see https://github.com/mpdf/mpdf/issues/642
 		 */
+		$lookAheadToc = null;
+		$lookAheadPageNumSubstitutions = null;
 		if (!$this->tocTocPaintBegun) {
-			$copier = new DeepCopy(true);
-			$tocClassClone = $copier->copy($this);
-			$tocClassClone->beginTocPaint();
-			$tocClassClone->insertTOC();
-			$this->_toc = $tocClassClone->_toc;
+			$mpdfState = $this->mpdf->getStateSnapshot();
+			$mTocState = $this->m_TOC;
+
+			$this->beginTocPaint();
+			$this->insertTOC();
+
+			$lookAheadToc = $this->_toc;
+			$lookAheadPageNumSubstitutions = $this->mpdf->PageNumSubstitutions;
+
+			$this->mpdf->restoreStateSnapshot($mpdfState);
+			$this->m_TOC = $mTocState;
+			$this->tocTocPaintBegun = false;
 		}
 
 		$notocs = 0;
@@ -446,11 +455,11 @@ class TableOfContents
 			 * @see https://github.com/mpdf/mpdf/issues/792
 			 * @see https://github.com/mpdf/mpdf/issues/777
 			 */
-			if (isset($tocClassClone)) {
+			if ($lookAheadPageNumSubstitutions !== null) {
 				$this->mpdf->PageNumSubstitutions = array_map(function ($sub) {
 					$sub['suppress'] = '';
 					return $sub;
-				}, $tocClassClone->mpdf->PageNumSubstitutions);
+				}, $lookAheadPageNumSubstitutions);
 			}
 
 			// mPDF 5.6.31
@@ -589,10 +598,9 @@ class TableOfContents
 		}
 
 		/* Fix the over adjustment of the TOC and Page Substitutions values */
-		if (isset($tocClassClone)) {
-			$this->_toc = $tocClassClone->_toc;
-			$this->mpdf->PageNumSubstitutions = $tocClassClone->mpdf->PageNumSubstitutions;
-			unset($tocClassClone);
+		if ($lookAheadToc !== null) {
+			$this->_toc = $lookAheadToc;
+			$this->mpdf->PageNumSubstitutions = $lookAheadPageNumSubstitutions;
 		}
 	}
 

--- a/tests/Mpdf/FpdiTest.php
+++ b/tests/Mpdf/FpdiTest.php
@@ -416,4 +416,33 @@ class FpdiTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$contentStream = $pageTwo->getContentStream();
 		$this->assertSame(1, preg_match_all('~/TPL\d~', $contentStream));
 	}
+
+	/**
+	 * Regression test for https://github.com/mpdf/mpdf/issues/1206
+	 * and https://github.com/mpdf/mpdf/issues/1345
+	 *
+	 * Importing a PDF and building a TOC in the same document must not close the imported
+	 * file's stream. The former deep-copy TOC look-ahead duplicated the reader and errors
+	 * would occur when the discarded clone was garbage collected.
+	 */
+	public function testTocLookAheadKeepsImportedPdfStreamOpen()
+	{
+		$handle = fopen(__DIR__ . '/../data/pdfs/Noisy-Tube.pdf', 'rb');
+		$streamReader = new StreamReader($handle, true);
+
+		$pdf = new Mpdf();
+		$pdf->h2toc = ['H1' => 0];
+		$pdf->setSourceFile($streamReader);
+		$pdf->useTemplate($pdf->importPage(1));
+		$pdf->WriteHTML('<tocpagebreak links="on" /><h1>Heading</h1>');
+		$pdf->Close();
+
+		// A discarded look-ahead clone is cyclic, so force its destructor to run now
+		gc_collect_cycles();
+
+		$this->assertTrue(
+			is_resource($handle),
+			'The imported PDF stream must stay open after the TOC look-ahead (see #1206)'
+		);
+	}
 }


### PR DESCRIPTION
The Table of Contents look-ahead (which pre-computes final page numbers by running a trial pagination pass) previously deep-cloned the entire Mpdf object graph using myclabs/deep-copy. Replace that with an in-place snapshot/restore of the document's mutable state: run the trial pass, capture the corrected page numbers, roll the document back, then paint the TOC for real.

Besides dropping the dependency, this is faster and lighter, and it removes a fragile piece of machinery. The snapshot copies only scalar and array state (copy-on-write) instead of deep-cloning mPDF's cyclic graph of services, so the look-ahead no longer scales with document size and there is no whole-object clone to keep working as that graph grows. On a 100-page document with 4 TOCs it renders about 120ms quicker and peaks 4MB lower, and the underlying clone step is hundreds of times cheaper. Output stays byte-identical.

It also fixes a long-standing, intermittent crash. When a document imports a PDF (FPDI opens the file with `closeStream = true`) and also builds a TOC, deep-cloning the document duplicated FPDI's stream readers, and the discarded clone could close the original's file handle, surfacing as `feof`/`fseek`/`fread` errors during TOC generation (mpdf/mpdf#1206). With no clone there is no shared handle to close.

- Add Mpdf::getStateSnapshot()/restoreStateSnapshot() capturing scalar/array properties only (services, container, logger and buffer stay shared).
- Rewire TableOfContents::insertTOC() to snapshot -> trial -> restore -> paint, replacing the DeepCopy clone and its isset($tocClassClone) guards.
- Drop myclabs/deep-copy from composer.json (now only a phpunit dev transitive).

Output is pixel-identical to the deep-copy implementation, and the full test suite passes (976 tests). That count includes a regression test (`FpdiTest::testTocLookAheadKeepsImportedPdfStreamOpen`) which fails against the old deep-copy look-ahead and passes with the snapshot.

Fixes mpdf/mpdf#1206
Fixes mpdf/mpdf#1345

<details>
<summary>Why replace DeepCopy</summary>

Keeping the deep clone carried real downsides beyond the extra dependency:

- **It scales with document size.** Every TOC document deep-clones the whole Mpdf object graph at `Close()`. That is O(document state) — roughly 52ms on a small document, ~100ms on a 100-page one — plus a transient second copy of the entire graph in memory. None of it produces output; it exists only to read back the corrected page numbers.

- **Parts of the graph can't be cloned at all, and one such case is a documented crash.** DeepCopy has to run in graph mode (`new DeepCopy(true)`) because ServiceFactory wires every service with a back-reference to `$mpdf`, making the graph cyclic. And some of what it copies isn't copyable: the PSR-11 container can hold closures, and when a PDF is imported, FPDI (mixed into Mpdf via FpdiTrait) keeps reader objects backed by file streams opened with `closeStream = true`. A stream resource can't be duplicated, so the trial clone ends up sharing the one real handle with the live document — the isolation is illusory, and the lifetime of that shared handle hangs on when the cyclic clone gets garbage-collected. If it is collected while the document still needs the stream, the clone's reader `fclose()`s the shared handle and the original fails with `feof`/`ftell`/`fseek`/`fread` errors mid-render. That is the documented root cause of mpdf/mpdf#1206, and the same duplicated-reader path is behind the file-handle exhaustion reported when importing many PDFs at once. Because it depends on GC timing and on whether the parser re-reads the stream at output, it strikes intermittently — which is exactly how those reports read. Removing the clone removes the root cause: the snapshot never duplicates those objects, so the streams stay owned solely by the live document. It is also a clean no-regression — a document combining an imported PDF page with a TOC renders byte-for-byte and pixel-for-pixel identically before and after this change, with the imported stream still readable at `Output()`.

- **It's a latent maintenance trap.** Because the clone copies everything by default, any property or service added to Mpdf silently joins it. A new closure, resource, or stateful service can break the look-ahead as a subtle pagination or output difference, surfacing far from the change that caused it.

- **It's opaque.** With a deep clone it is hard to say exactly what is preserved versus shared. The snapshot states precisely what it captures (scalars and arrays) and what it deliberately leaves shared (services, container, logger, buffer), so the isolation is auditable.

- **Extra compatibility surface.** One more production `require` to keep working across mPDF's PHP 5.6–8.5 range, and a possible source of version-resolution conflicts in downstream projects. It now remains only as a phpunit dev transitive.

</details>

<details>
<summary>Alternatives considered</summary>

Two clone-free designs were considered and rejected before settling on the full in-place snapshot.

**Snapshot only the properties the TOC touches.** Painting the TOC drives a full `WriteHTML` pass, which mutates a large and hard-to-bound slice of document state: page arrays and cursors, font and colour state, link tables, footnote and column counters, page-number substitutions, and whatever the back-referencing services write back onto `$mpdf`. Enumerating that set by hand is fragile — miss one property and the trial pass bleeds state into the real render, producing subtle pagination or pixel differences that only the snapshot CI job would catch, far from the code that caused them. It also buys almost nothing: PHP arrays are copy-on-write, so the wide snapshot copies references and only duplicates an array's contents when the trial pass actually mutates it (exactly the properties a hand-picked list would have to include anyway). The wide capture is correct by construction and stays correct as the TOC and layout code evolve, at negligible cost. If it ever needs bounding, a blocklist of known-large, known-irrelevant buffers is the safer direction than an allowlist of "TOC-touched" state.

**A look-ahead that never writes to the document.** Instead of a trial render, emit placeholder tokens for the page numbers and substitute the real values at output — the mechanism mPDF already uses for `{nb}`/`{nbpg}`. A prototype did exactly this in a single pass with no snapshot at all, and it produced identical output for fixed-width page numbering. It cannot be made correct in general, though: a TOC line's dot-leader length and right-aligned number position depend on the rendered width of the page number, which is not known until the number exists. With variable-width numbering (Roman numerals — VII vs VIII vs IX, or any styled sequence) the alignment and dot count differ per entry, so a fixed-width placeholder reserves the wrong space and the output shifts. Only a real pagination pass yields pixel-correct TOC layout, so the look-ahead writes to the document — against a snapshot it can roll back — rather than deferring substitution.

</details>

<details>
<summary>Performance benchmarks</summary>

Measured on PHP 7.4.33, best-of-5 fresh-process runs. In every case the two implementations produced byte-identical output — same page count, same TOC landing pages, same bookmarks.

**End-to-end render** — 100-page document, 4 TOCs landing on pages 2/10/25/40, 30 entries, pages cycling through bordered/zebra tables, nested tables, 3-column CSS, and embedded PNG + SVG images:

| Implementation | Best time | Peak memory |
| --- | --- | --- |
| deep-copy (before) | 1816 ms | 30.0 MB |
| snapshot (after) | 1695 ms | 26.0 MB |
| **change** | **−121 ms (−6.7%)** | **−4 MB (−13%)** |

**The clone step in isolation** — the only thing that changed — timed on identical built state (15 iterations, median):

| Document state | deep-copy | snapshot | speedup |
| --- | --- | --- | --- |
| 11 pages | 52.5 ms | 0.10 ms | 536× |
| 121 pages | 76.2 ms | 0.10 ms | 778× |
| 251 pages | 106.6 ms | 0.10 ms | 1075× |
| 100 pages, 4 TOCs | 100.4 ms | 0.15 ms | 664× |

`restoreStateSnapshot()` adds about 0.02ms. The snapshot is flat at ~0.1ms because it copies property references (copy-on-write), making it O(1) at capture regardless of document size, whereas the deep clone grows with the object graph. That is why nearly all of the end-to-end saving is eliminated clone overhead — and why the gap widens on larger documents. Peak memory drops because the deep clone transiently duplicated the whole graph mid-`Close()`; the snapshot never does.

</details>
